### PR TITLE
Option to prevent fetch story

### DIFF
--- a/packages/vsf-storyblok-module/components/StoryblokMixin.ts
+++ b/packages/vsf-storyblok-module/components/StoryblokMixin.ts
@@ -41,7 +41,8 @@ export default {
     return {
       storyblok: {
         prependStorecode: false,
-        path: ''
+        path: '',
+        fetchStory: true
       }
     }
   },
@@ -55,6 +56,9 @@ export default {
       return fullSlug
     },
     async fetchStory () {
+      if (this.storyblok.fetchStory === false) {
+        return
+      }
       const { id, fullSlug, spaceId, timestamp, token } = getStoryblokQueryParams(this.$route)
 
       if (id && !this.storyblokPath) {


### PR DESCRIPTION
**Problem**
Whenever you use the `StoryblokMixin.ts` it will try and fetch a story for the current url.
We are using the mixin in a header component on our site.
This result in a http request with 404 result for every page on our site.
If you want to use the `StoryblokMixin.ts` without this undesired behavior we need to be able to tell it not to.

**Solution**
Added a data property `storyblok.fetchStory` (default `true`) that will control if a story should be fetched or not. When using the mixin in a component, just add this property set to `false` to prevent the fetch:
```
data () {
  return {
    storyblok: {
      fetchStory: false
    }
  }
}
```