### PR TITLE
Fix preview editor after VSF upgrade

### DIFF
--- a/packages/vsf-storyblok-module/store/actions.ts
+++ b/packages/vsf-storyblok-module/store/actions.ts
@@ -37,7 +37,8 @@ export const actions: ActionTree<StoryblokState, RootState> = {
     const url = `${config.storyblok.endpoint}/validate-editor/?${qs.stringify(query)}`
     const { result: { previewToken } }: any = await TaskQueue.execute({
       url,
-      silent: true
+      silent: true,
+      payload: { headers: [] }
     })
 
     commit('setPreviewToken', { previewToken })


### PR DESCRIPTION
Introduced by changes in `task.ts` in VSF core.